### PR TITLE
Update otherMethods.py

### DIFF
--- a/otherMethods.py
+++ b/otherMethods.py
@@ -67,7 +67,6 @@ class otherMethods:
         headers = requests.head(url, allow_redirects=True).headers
         if cls.is_downloadable(headers):
             expected_file_size = int(headers['content-length']) 
-            file_name = "" 
             if bundle_dict: 
                 file_name = bundle_dict['name'] + ".tar"
             else: 

--- a/otherMethods.py
+++ b/otherMethods.py
@@ -49,7 +49,7 @@ class otherMethods:
         results_list = []
         for availableDownload in availableDownloads:
             url = availableDownload['url']
-            if (productName.find('Bundle') == -1):
+            if productName.find('Bundle') == -1:
                 path = cls._download(url, output_dir)
             else: 
                 path = cls._download(url, output_dir, bundle_dict={'name': url[url.find("product_id=") + len("product_id="):url.find("product_id=") + len("product_id=") + 38]})


### PR DESCRIPTION
Hi @MrChebur! Been using your python wrapper for a research project where we are gathering USGS data. 

Noticed that when I try downloading data from any "BUNDLE" product under any dataset (eg, landsat_ba_tile_c2), the  ```requests.head(url, allow_redirects=True).headers``` [Line 67] in the ```otherMethods.py``` file returns a 400 Error. 
This seems to be an issue from the AWS side, and we get an error message within the JSON object. 

To solve this, I am currently checking whether the requested product is a BUNDLE product, and just find the name of the file from the ```url``` within the class and save it based on that. 

The changes are in the ```download() ``` and ```_download()``` functions. 

These changes seem to be a more of a quick fix since the wrapper only faces issues with ```.tar``` files. Hopefully, they are acceptable to you. 